### PR TITLE
Use ZMQ::Error instead of RuntimeErrors

### DIFF
--- a/rbzmq.c
+++ b/rbzmq.c
@@ -63,6 +63,7 @@ typedef unsigned __int64 uint64_t;
     } while(0)
 
 VALUE socket_type;
+VALUE exception_type;
 
 /*
  * Document-class: ZMQ
@@ -124,7 +125,7 @@ static VALUE context_initialize (int argc_, VALUE* argv_, VALUE self_)
     assert (!DATA_PTR (self_));
     void *ctx = zmq_init (NIL_P (io_threads) ? 1 : NUM2INT (io_threads));
     if (!ctx) {
-        rb_raise (rb_eRuntimeError, "%s", zmq_strerror (zmq_errno ()));
+        rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
         return Qnil;
     }
 
@@ -328,7 +329,7 @@ static VALUE internal_select(VALUE argval)
         rc = zmq_poll (ps.items, ps.nitems, arg->timeout_usec);
     
     if (rc == -1) {
-        rb_raise(rb_eRuntimeError, "%s", zmq_strerror (zmq_errno ()));
+        rb_raise(exception_type, "%s", zmq_strerror (zmq_errno ()));
         return Qnil;
     }
     else if (rc == 0)
@@ -433,7 +434,7 @@ static VALUE context_socket (VALUE self_, VALUE type_)
     Data_Get_Struct (self_, void, c);
     void * s = zmq_socket (c, NUM2INT (type_));
     if (!s) {
-        rb_raise (rb_eRuntimeError, "%s", zmq_strerror (zmq_errno ()));
+        rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
         return Qnil;
     }
 
@@ -933,7 +934,7 @@ static VALUE socket_getsockopt (VALUE self_, VALUE option_)
                                  &optvalsize);
 
             if (rc != 0) {
-              rb_raise (rb_eRuntimeError, "%s", zmq_strerror (zmq_errno ()));
+              rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
               return Qnil;
             }
 
@@ -952,7 +953,7 @@ static VALUE socket_getsockopt (VALUE self_, VALUE option_)
                                  &optvalsize);
 
             if (rc != 0) {
-              rb_raise (rb_eRuntimeError, "%s", zmq_strerror (zmq_errno ()));
+              rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
               return Qnil;
             }
 
@@ -978,7 +979,7 @@ static VALUE socket_getsockopt (VALUE self_, VALUE option_)
                                  &optvalsize);
 
             if (rc != 0) {
-              rb_raise (rb_eRuntimeError, "%s", zmq_strerror (zmq_errno ()));
+              rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
               return Qnil;
             }
 
@@ -1006,7 +1007,7 @@ static VALUE socket_getsockopt (VALUE self_, VALUE option_)
                                  &optvalsize);
 
             if (rc != 0) {
-              rb_raise (rb_eRuntimeError, "%s", zmq_strerror (zmq_errno ()));
+              rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
               return Qnil;
             }
 
@@ -1025,7 +1026,7 @@ static VALUE socket_getsockopt (VALUE self_, VALUE option_)
                                  &optvalsize);
 
             if (rc != 0) {
-              rb_raise (rb_eRuntimeError, "%s", zmq_strerror (zmq_errno ()));
+              rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
               return Qnil;
             }
 
@@ -1036,7 +1037,7 @@ static VALUE socket_getsockopt (VALUE self_, VALUE option_)
         }
         break;
     default:
-        rb_raise (rb_eRuntimeError, "%s", zmq_strerror (EINVAL));
+        rb_raise (exception_type, "%s", zmq_strerror (EINVAL));
         return Qnil;
     }
   
@@ -1337,12 +1338,12 @@ static VALUE socket_setsockopt (VALUE self_, VALUE option_,
         break;
 
     default:
-        rb_raise (rb_eRuntimeError, "%s", zmq_strerror (EINVAL));
+        rb_raise (exception_type, "%s", zmq_strerror (EINVAL));
         return Qnil;
     }
 
     if (rc != 0) {
-        rb_raise (rb_eRuntimeError, "%s", zmq_strerror (zmq_errno ()));
+        rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
         return Qnil;
     }
 
@@ -1381,7 +1382,7 @@ static VALUE socket_bind (VALUE self_, VALUE addr_)
 
     int rc = zmq_bind (s, rb_string_value_cstr (&addr_));
     if (rc != 0) {
-        rb_raise (rb_eRuntimeError, "%s", zmq_strerror (zmq_errno ()));
+        rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
         return Qnil;
     }
 
@@ -1424,7 +1425,7 @@ static VALUE socket_connect (VALUE self_, VALUE addr_)
 
     int rc = zmq_connect (s, rb_string_value_cstr (&addr_));
     if (rc != 0) {
-        rb_raise (rb_eRuntimeError, "%s", zmq_strerror (zmq_errno ()));
+        rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
         return Qnil;
     }
 
@@ -1501,7 +1502,7 @@ static VALUE socket_send (int argc_, VALUE* argv_, VALUE self_)
     zmq_msg_t msg;
     int rc = zmq_msg_init_size (&msg, RSTRING_LEN (msg_));
     if (rc != 0) {
-        rb_raise (rb_eRuntimeError, "%s", zmq_strerror (zmq_errno ()));
+        rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
         return Qnil;
     }
     memcpy (zmq_msg_data (&msg), RSTRING_PTR (msg_), RSTRING_LEN (msg_));
@@ -1525,7 +1526,7 @@ static VALUE socket_send (int argc_, VALUE* argv_, VALUE self_)
     }
 
     if (rc != 0) {
-        rb_raise (rb_eRuntimeError, "%s", zmq_strerror (zmq_errno ()));
+        rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
         rc = zmq_msg_close (&msg);
         assert (rc == 0);
         return Qnil;
@@ -1610,7 +1611,7 @@ static VALUE socket_recv (int argc_, VALUE* argv_, VALUE self_)
     }
 
     if (rc != 0) {
-        rb_raise (rb_eRuntimeError, "%s", zmq_strerror (zmq_errno ()));
+        rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
         rc = zmq_msg_close (&msg);
         assert (rc == 0);
         return Qnil;
@@ -1641,7 +1642,7 @@ static VALUE socket_close (VALUE self_)
     if (s != NULL) {
         int rc = zmq_close (s);
         if (rc != 0) {
-            rb_raise (rb_eRuntimeError, "%s", zmq_strerror (zmq_errno ()));
+            rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
             return Qnil;
         }
 
@@ -1655,6 +1656,8 @@ void Init_zmq ()
     VALUE zmq_module = rb_define_module ("ZMQ");
     rb_define_singleton_method (zmq_module, "version", module_version, 0);
     rb_define_singleton_method (zmq_module, "select", module_select, -1);
+
+	exception_type = rb_define_class_under (zmq_module, "Error", rb_eRuntimeError );
 
     VALUE context_type = rb_define_class_under (zmq_module, "Context",
         rb_cObject);

--- a/rbzmq.c
+++ b/rbzmq.c
@@ -1657,7 +1657,7 @@ void Init_zmq ()
     rb_define_singleton_method (zmq_module, "version", module_version, 0);
     rb_define_singleton_method (zmq_module, "select", module_select, -1);
 
-	exception_type = rb_define_class_under (zmq_module, "Error", rb_eRuntimeError );
+    exception_type = rb_define_class_under (zmq_module, "Error", rb_eRuntimeError );
 
     VALUE context_type = rb_define_class_under (zmq_module, "Context",
         rb_cObject);


### PR DESCRIPTION
When wrapping error-handling around zmq calls, one is forced to parse the error message to distinguish between zmq errors and other RuntimeErrors. This patch adds a ZMQ::Error exception class that inherits from RuntimeError, and changes all instances of `rb_raise( rb_eRuntimeError, ... )` to raise the new exception type instead.
