### PR TITLE
handle EINTR in send

### DIFF
--- a/rbzmq.c
+++ b/rbzmq.c
@@ -56,19 +56,9 @@ typedef unsigned __int64 uint64_t;
 #include <stdint.h>
 #endif
 
-struct zmq_context {
-    void *context;
-    unsigned refs;
-};
-
-struct zmq_socket {
-    void *socket;
-    struct zmq_context *context;
-};
-
 #define Check_Socket(__socket) \
     do {\
-        if ((__socket->socket) == NULL)\
+        if ((__socket) == NULL)\
             rb_raise (rb_eIOError, "closed socket");\
     } while(0)
 
@@ -102,32 +92,17 @@ static VALUE module_version (VALUE self_)
  * ZeroMQ library context.
  */
 
-static void context_free (void *ptr)
+static void context_free (void *ctx)
 {
-    struct zmq_context * ctx = (struct zmq_context *)ptr;
-
-    assert(ctx->refs != 0);
-    ctx->refs--;
-
-    if (ctx->refs == 0) {
-        if (ctx->context != NULL) {
-            int rc = zmq_term(ctx->context);
-            assert (rc == 0);
-        }
-
-        xfree(ctx);
+    if (ctx) {
+       int rc = zmq_term (ctx);
+       assert (rc == 0);
     }
 }
 
 static VALUE context_alloc (VALUE class_)
 {
-    struct zmq_context * ctx;
-
-    ctx = ALLOC(struct zmq_context);
-    ctx->context = NULL;
-    ctx->refs = 1;
-
-    return rb_data_object_alloc (class_, ctx, 0, context_free);
+    return rb_data_object_alloc (class_, NULL, 0, context_free);
 }
 
 /*
@@ -147,17 +122,14 @@ static VALUE context_initialize (int argc_, VALUE* argv_, VALUE self_)
     VALUE io_threads;
     rb_scan_args (argc_, argv_, "01", &io_threads);
 
-    struct zmq_context * ctx = NULL;
-    Data_Get_Struct (self_, void, ctx);
-
-    assert (ctx->context == NULL);
-    void *zctx = zmq_init (NIL_P (io_threads) ? 1 : NUM2INT (io_threads));
-    if (!zctx) {
+    assert (!DATA_PTR (self_));
+    void *ctx = zmq_init (NIL_P (io_threads) ? 1 : NUM2INT (io_threads));
+    if (!ctx) {
         rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
         return Qnil;
     }
 
-    ctx->context = zctx;
+    DATA_PTR (self_) = (void*) ctx;
     return self_;
 }
 
@@ -187,14 +159,14 @@ static VALUE context_initialize (int argc_, VALUE* argv_, VALUE self_)
  */
 static VALUE context_close (VALUE self_)
 {
-    struct zmq_context * ctx = NULL;
+    void * ctx = NULL;
     Data_Get_Struct (self_, void, ctx);
     
-    if (ctx->context != NULL) {
-        int rc = zmq_term(ctx->context);
+    if (ctx != NULL) {
+        int rc = zmq_term (ctx);
         assert (rc == 0);
 
-        ctx->context = NULL;
+        DATA_PTR (self_) = NULL;
     }
 
     return Qnil;
@@ -250,10 +222,7 @@ static VALUE poll_add_item(VALUE io_, void *ps_) {
     item->events = state->event;
 
     if (CLASS_OF (io_) == socket_type) {
-        struct zmq_socket *s;
-        Data_Get_Struct (io_, struct zmq_socket, s);
-      
-        item->socket = s->socket;
+        item->socket = DATA_PTR (io_);
         item->fd = -1;
     }
     else {
@@ -395,14 +364,14 @@ static VALUE module_select_internal(VALUE readset, VALUE writeset, VALUE errset,
     nitems = (NIL_P (readset) ? 0 : RARRAY_LEN (readset)) +
              (NIL_P (writeset) ? 0 : RARRAY_LEN (writeset)) +
              (NIL_P (errset) ? 0 : RARRAY_LEN (errset));
-    arg.items = ALLOC_N(zmq_pollitem_t, nitems);
+    arg.items = (zmq_pollitem_t*)ruby_xmalloc(sizeof(zmq_pollitem_t) * nitems);
 
     arg.readset = readset;
     arg.writeset = writeset;
     arg.errset = errset;
     arg.timeout_usec = timeout_usec;
 
-    return rb_ensure(internal_select, (VALUE)&arg, (VALUE (*)())xfree, (VALUE)arg.items);
+    return rb_ensure(internal_select, (VALUE)&arg, (VALUE (*)())ruby_xfree, (VALUE)arg.items);
 }
 
 /*
@@ -430,21 +399,12 @@ static VALUE module_select (int argc_, VALUE* argv_, VALUE self_)
     return module_select_internal(readset, writeset, errset, timeout_usec);
 }
 
-static void socket_free (void *ptr)
+static void socket_free (void *s)
 {
-    struct zmq_socket *s = (struct zmq_socket *)ptr;
-
-    if (s->socket != NULL) {
-        int rc = zmq_close(s->socket);
-        assert (rc == 0);
+    if (s) {
+       int rc = zmq_close (s);
+       assert (rc == 0);
     }
-
-    if (s->context != NULL) {
-        /* Decrement the refcounter for the context (and possibly free it). */
-        context_free(s->context);
-    }
-
-    xfree(s);
 }
 
 /*
@@ -466,28 +426,13 @@ static void socket_free (void *ptr)
  */
 static VALUE context_socket (VALUE self_, VALUE type_)
 {
-    struct zmq_context * ctx = NULL;
-    void *socket;
-    struct zmq_socket *s;
-
-    Data_Get_Struct (self_, void, ctx);
-    
-    socket = zmq_socket(ctx->context, NUM2INT (type_));
-    if (!socket) {
+    void * c = NULL;
+    Data_Get_Struct (self_, void, c);
+    void * s = zmq_socket (c, NUM2INT (type_));
+    if (!s) {
         rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
         return Qnil;
     }
-
-    s = ALLOC(struct zmq_socket);
-
-    /*
-     * Grab a reference on the context, to prevent it from being garbage-
-     * collected before the socket is closed.
-     */
-    s->context = ctx;
-    s->context->refs++;
-
-    s->socket = socket;
 
     return Data_Wrap_Struct(socket_type, 0, socket_free, s);
 }
@@ -965,9 +910,9 @@ static VALUE socket_getsockopt (VALUE self_, VALUE option_)
 {
     int rc = 0;
     VALUE retval;
-    struct zmq_socket * s;
-
-    Data_Get_Struct (self_, struct zmq_socket, s);
+    void * s;
+    
+    Data_Get_Struct (self_, void, s);
     Check_Socket (s);
   
     switch (NUM2INT (option_)) {
@@ -981,7 +926,7 @@ static VALUE socket_getsockopt (VALUE self_, VALUE option_)
 #endif
             size_t optvalsize = sizeof(optval);
 
-            rc = zmq_getsockopt (s->socket, NUM2INT (option_), (void *)&optval,
+            rc = zmq_getsockopt (s, NUM2INT (option_), (void *)&optval,
                                  &optvalsize);
 
             if (rc != 0) {
@@ -1000,7 +945,7 @@ static VALUE socket_getsockopt (VALUE self_, VALUE option_)
             uint32_t optval;
             size_t optvalsize = sizeof(optval);
 
-            rc = zmq_getsockopt (s->socket, NUM2INT (option_), (void *)&optval,
+            rc = zmq_getsockopt (s, NUM2INT (option_), (void *)&optval,
                                  &optvalsize);
 
             if (rc != 0) {
@@ -1026,7 +971,7 @@ static VALUE socket_getsockopt (VALUE self_, VALUE option_)
             int optval;
             size_t optvalsize = sizeof(optval);
 
-            rc = zmq_getsockopt (s->socket, NUM2INT (option_), (void *)&optval,
+            rc = zmq_getsockopt (s, NUM2INT (option_), (void *)&optval,
                                  &optvalsize);
 
             if (rc != 0) {
@@ -1054,7 +999,7 @@ static VALUE socket_getsockopt (VALUE self_, VALUE option_)
             int64_t optval;
             size_t optvalsize = sizeof(optval);
 
-            rc = zmq_getsockopt (s->socket, NUM2INT (option_), (void *)&optval,
+            rc = zmq_getsockopt (s, NUM2INT (option_), (void *)&optval,
                                  &optvalsize);
 
             if (rc != 0) {
@@ -1073,8 +1018,8 @@ static VALUE socket_getsockopt (VALUE self_, VALUE option_)
             char identity[255];
             size_t optvalsize = sizeof (identity);
 
-            rc = zmq_getsockopt (s->socket, NUM2INT (option_),
-                                 (void *)identity, &optvalsize);
+            rc = zmq_getsockopt (s, NUM2INT (option_), (void *)identity,
+                                 &optvalsize);
 
             if (rc != 0) {
               rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
@@ -1175,7 +1120,7 @@ static VALUE socket_getsockopt (VALUE self_, VALUE option_)
  * [Default value] nil
  * [Applicable socket types] all
  *
- * == ZMQ::SUBSCRIBE: Establish message filter
+ * ZMQ::SUBSCRIBE: Establish message filter
  * The ZMQ::SUBSCRIBE option shall establish a new message filter on a ZMQ::SUB
  * socket. Newly created ZMQ::SUB sockets shall filter out all incoming messages,
  * therefore you should call this option to establish an initial message filter.
@@ -1338,9 +1283,9 @@ static VALUE socket_setsockopt (VALUE self_, VALUE option_,
 {
 
     int rc = 0;
-    struct zmq_socket * s;
+    void * s;
 
-    Data_Get_Struct (self_, struct zmq_socket, s);
+    Data_Get_Struct (self_, void, s);
     Check_Socket (s);
 
     switch (NUM2INT (option_)) {
@@ -1356,7 +1301,7 @@ static VALUE socket_setsockopt (VALUE self_, VALUE option_,
 	        uint64_t optval = FIX2LONG (optval_);
 
 	        //  Forward the code to native 0MQ library.
-	        rc = zmq_setsockopt (s->socket, NUM2INT (option_),
+	        rc = zmq_setsockopt (s, NUM2INT (option_),
 	            (void*) &optval, sizeof (optval));
 	    }
 	    break;
@@ -1373,7 +1318,7 @@ static VALUE socket_setsockopt (VALUE self_, VALUE option_,
             int optval = FIX2INT (optval_);
 
             //  Forward the code to native 0MQ library.
-            rc = zmq_setsockopt (s->socket, NUM2INT (option_),
+            rc = zmq_setsockopt (s, NUM2INT (option_),
                 (void*) &optval, sizeof (optval));
         }
         break;
@@ -1384,7 +1329,7 @@ static VALUE socket_setsockopt (VALUE self_, VALUE option_,
     case ZMQ_UNSUBSCRIBE:
 
         //  Forward the code to native 0MQ library.
-        rc = zmq_setsockopt (s->socket, NUM2INT (option_),
+        rc = zmq_setsockopt (s, NUM2INT (option_),
 	    (void *) StringValueCStr (optval_), RSTRING_LEN (optval_));
         break;
 
@@ -1427,11 +1372,11 @@ static VALUE socket_setsockopt (VALUE self_, VALUE option_,
  */
 static VALUE socket_bind (VALUE self_, VALUE addr_)
 {
-    struct zmq_socket * s;
-    Data_Get_Struct (self_, struct zmq_socket, s);
+    void * s;
+    Data_Get_Struct (self_, void, s);
     Check_Socket (s);
 
-    int rc = zmq_bind (s->socket, rb_string_value_cstr (&addr_));
+    int rc = zmq_bind (s, rb_string_value_cstr (&addr_));
     if (rc != 0) {
         rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
         return Qnil;
@@ -1470,11 +1415,11 @@ static VALUE socket_bind (VALUE self_, VALUE addr_)
  */
 static VALUE socket_connect (VALUE self_, VALUE addr_)
 {
-    struct zmq_socket * s;
-    Data_Get_Struct (self_, struct zmq_socket, s);
+    void * s;
+    Data_Get_Struct (self_, void, s);
     Check_Socket (s);
 
-    int rc = zmq_connect (s->socket, rb_string_value_cstr (&addr_));
+    int rc = zmq_connect (s, rb_string_value_cstr (&addr_));
     if (rc != 0) {
         rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
         return Qnil;
@@ -1542,8 +1487,8 @@ static VALUE socket_send (int argc_, VALUE* argv_, VALUE self_)
     
     rb_scan_args (argc_, argv_, "11", &msg_, &flags_);
 
-    struct zmq_socket * s;
-    Data_Get_Struct (self_, struct zmq_socket, s);
+    void * s;
+    Data_Get_Struct (self_, void, s);
     Check_Socket (s);
 
     Check_Type (msg_, T_STRING);
@@ -1551,18 +1496,17 @@ static VALUE socket_send (int argc_, VALUE* argv_, VALUE self_)
     int flags = NIL_P (flags_) ? 0 : NUM2INT (flags_);
 
     zmq_msg_t msg;
-    int msg_len = (int)RSTRING_LEN (msg_);
-    int rc = zmq_msg_init_size (&msg, msg_len);
+    int rc = zmq_msg_init_size (&msg, RSTRING_LEN (msg_));
     if (rc != 0) {
         rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
         return Qnil;
     }
-    memcpy (zmq_msg_data (&msg), RSTRING_PTR (msg_), msg_len);
+    memcpy (zmq_msg_data (&msg), RSTRING_PTR (msg_), RSTRING_LEN (msg_));
 
 #ifdef HAVE_RUBY_INTERN_H
     if (!(flags & ZMQ_NOBLOCK)) {
         struct zmq_send_recv_args send_args;
-        send_args.socket = s->socket;
+        send_args.socket = s;
         send_args.msg = &msg;
         send_args.flags = flags;
         rb_thread_blocking_region (zmq_send_blocking, (void*) &send_args, NULL, NULL);
@@ -1570,15 +1514,14 @@ static VALUE socket_send (int argc_, VALUE* argv_, VALUE self_)
     }
     else
 #endif
-
-     // When system call is interrupted, try up to 5 times
      int loop_count = 0;
-     do {
+      do {
           loop_count++;
           if (loop_count>5)
-             rb_raise (exception_type, "Loop count limit exceeded: %s", zmq_strerror (zmq_errno ()));
-          rc = zmq_send(s, &msg, flags);
-     } while ((rc != 0) && (zmq_errno() == EINTR));
+                  rb_raise (exception_type, "Loop count limit exceeded: %s", zmq_strerror (zmq_errno ()));
+        rc = zmq_send(s, &msg, flags);
+        } while ((rc != 0) && (zmq_errno() == EINTR));
+
 
     if (rc != 0 && zmq_errno () == EAGAIN) {
         rc = zmq_msg_close (&msg);
@@ -1642,8 +1585,8 @@ static VALUE socket_recv (int argc_, VALUE* argv_, VALUE self_)
     
     rb_scan_args (argc_, argv_, "01", &flags_);
 
-    struct zmq_socket * s;
-    Data_Get_Struct (self_, struct zmq_socket, s);
+    void * s;
+    Data_Get_Struct (self_, void, s);
     Check_Socket (s);
 
     int flags = NIL_P (flags_) ? 0 : NUM2INT (flags_);
@@ -1655,7 +1598,7 @@ static VALUE socket_recv (int argc_, VALUE* argv_, VALUE self_)
 #ifdef HAVE_RUBY_INTERN_H
     if (!(flags & ZMQ_NOBLOCK)) {
         struct zmq_send_recv_args recv_args;
-        recv_args.socket = s->socket;
+        recv_args.socket = s;
         recv_args.msg = &msg;
         recv_args.flags = flags;
         rb_thread_blocking_region (zmq_recv_blocking, (void*) &recv_args,
@@ -1664,7 +1607,7 @@ static VALUE socket_recv (int argc_, VALUE* argv_, VALUE self_)
     }
     else
 #endif
-        rc = zmq_recv (s->socket, &msg, flags);
+        rc = zmq_recv (s, &msg, flags);
     if (rc != 0 && zmq_errno () == EAGAIN) {
         rc = zmq_msg_close (&msg);
         assert (rc == 0);
@@ -1698,20 +1641,16 @@ static VALUE socket_recv (int argc_, VALUE* argv_, VALUE self_)
  */
 static VALUE socket_close (VALUE self_)
 {
-    struct zmq_socket * s;
-    Data_Get_Struct (self_, struct zmq_socket, s);
-    if (s->socket != NULL) {
-        int rc = zmq_close(s->socket);
+    void * s = NULL;
+    Data_Get_Struct (self_, void, s);
+    if (s != NULL) {
+        int rc = zmq_close (s);
         if (rc != 0) {
             rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
             return Qnil;
         }
 
-        s->socket = NULL;
-
-        /* Decrement the refcounter for the context (and possibly free it). */
-        context_free(s->context);
-        s->context = NULL;
+        DATA_PTR (self_) = NULL;
     }
     return Qnil;
 }


### PR DESCRIPTION
This patch avoids the problem of the exception "ZMQ::Error: Interrupted system call" when sending messages. It tries up to 5 times to send the message, and gives up if all attempts are interrupted. This can probably be left out, but I didn't want to take any risk in my production environment, where this code has been running fine for some weeks now. (And 5 attempts were not needed to send the messages)
