### PR TITLE
libstdc++ needs to be added manually for the gem to compile under cygwin

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -19,6 +19,8 @@
 require 'mkmf'
 dir_config('zmq')
 
+$libs += ' -lstdc++ '
+
 $CFLAGS += ' -std=c99'
 CONFIG['warnflags'].gsub!(/-Wdeclaration-after-statement|-Wunused-parameter/, '') if CONFIG['warnflags']
 


### PR DESCRIPTION
For some reason, the gem won't build on Cygwin unless libstdc++ is added manually through $libs += ' -lstdc++ '.
