### PR TITLE
Fix order of arguments in zmq_msg_send and zmq_msg_recv.  

### DIFF
--- a/rbzmq.c
+++ b/rbzmq.c
@@ -1659,7 +1659,7 @@ static VALUE zmq_send_blocking (void* args_)
 {
     struct zmq_send_recv_args *send_args = (struct zmq_send_recv_args *)args_;
 
-    send_args->rc = zmq_msg_send(send_args->socket, send_args->msg, send_args->flags);
+    send_args->rc = zmq_msg_send(send_args->msg, send_args->socket, send_args->flags);
     
     return Qnil;
 }
@@ -1734,7 +1734,7 @@ static VALUE socket_send (int argc_, VALUE* argv_, VALUE self_)
     }
     else
 #endif
-        rc = zmq_msg_send (s->socket, &msg, flags);
+        rc = zmq_msg_send (&msg, s->socket, flags);
     if (rc == -1 && zmq_errno () == EAGAIN) {
         rc = zmq_msg_close (&msg);
         assert (rc == 0);
@@ -1758,7 +1758,7 @@ static VALUE zmq_recv_blocking (void* args_)
 {
     struct zmq_send_recv_args *recv_args = (struct zmq_send_recv_args *)args_;
 
-    recv_args->rc = zmq_msg_recv(recv_args->socket, recv_args->msg, recv_args->flags);
+    recv_args->rc = zmq_msg_recv(recv_args->msg, recv_args->socket, recv_args->flags);
     
     return Qnil;
 }
@@ -1819,7 +1819,7 @@ static VALUE socket_recv (int argc_, VALUE* argv_, VALUE self_)
     }
     else
 #endif
-        rc = zmq_msg_recv (s->socket, &msg, flags);
+        rc = zmq_msg_recv (&msg, s->socket, flags);
     if (rc == -1 && zmq_errno () == EAGAIN) {
         rc = zmq_msg_close (&msg);
         assert (rc == 0);

--- a/rbzmq.c
+++ b/rbzmq.c
@@ -170,7 +170,7 @@ static VALUE context_initialize (int argc_, VALUE* argv_, VALUE self_)
     Data_Get_Struct (self_, void, ctx);
 
     assert (ctx->context == NULL);
-    void *zctx = zmq_init (NIL_P (io_threads) ? 1 : NUM2INT (io_threads));
+    void *zctx = zmq_ctx_new();
     if (!zctx) {
         rb_raise (exception_type, "%s", zmq_strerror (zmq_errno ()));
         return Qnil;


### PR DESCRIPTION
This clears up the 'Socket operation on non-socket' error in issue #25, for me.  Also swapped the deprecated zmq_init in favor of zmq_ctx_new.
